### PR TITLE
Remove useless gradle config

### DIFF
--- a/prado/build.gradle
+++ b/prado/build.gradle
@@ -23,8 +23,6 @@ android {
 dependencies {
   def supportLibVersion = '25.3.1'
 
-  compile fileTree(dir: 'libs', include: ['*.jar'])
-
   compile "org.jetbrains.kotlin:kotlin-stdlib:" + kotlin_version
   compile "com.android.support:recyclerview-v7:" + supportLibVersion
   compile "com.android.support:appcompat-v7:" + supportLibVersion

--- a/sample-java/build.gradle
+++ b/sample-java/build.gradle
@@ -23,10 +23,6 @@ android {
 
 dependencies {
   compile project(':prado')
-  androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-    exclude group: 'com.android.support', module: 'support-annotations'
-  })
   compile 'com.android.support:appcompat-v7:25.3.1'
   compile 'com.android.support.constraint:constraint-layout:1.0.2'
-  testCompile 'junit:junit:4.12'
 }

--- a/sample-java/build.gradle
+++ b/sample-java/build.gradle
@@ -22,7 +22,6 @@ android {
 }
 
 dependencies {
-  compile fileTree(dir: 'libs', include: ['*.jar'])
   compile project(':prado')
   androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
     exclude group: 'com.android.support', module: 'support-annotations'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -25,7 +25,6 @@ android {
 }
 
 dependencies {
-  compile fileTree(dir: 'libs', include: ['*.jar'])
   compile project(':prado')
   compile 'com.android.support:appcompat-v7:25.3.1'
   compile 'com.android.support.constraint:constraint-layout:1.0.2'


### PR DESCRIPTION
Remove compiling libs and useless testing dependencies from sample-java since we don't test anything on samples.
Solves #5 